### PR TITLE
(suggestion) add websocket apis

### DIFF
--- a/export/recent_updates.css
+++ b/export/recent_updates.css
@@ -1,0 +1,119 @@
+body { 
+    background-color: rgba(0, 0, 0, 0.95);
+    font-family:"Meiryo";
+    color: #fff;
+    overflow: visible;
+}
+
+div#setting {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: absolute;
+    padding: 100px 50px;
+}
+
+div#setting #box {
+    height: 10px;
+}
+
+div#setting span {
+}
+
+div#setting span#url {
+    width: 300px;
+    color: black;
+    background-color: white;
+    padding: 2px 5px;
+    border-style: solid;
+    border-width: 1px;
+    font-size: large;
+}
+
+
+#content{
+    display: none;
+}
+
+#title {
+    color: #aaddff;
+    background-color: rgba(0, 0, 0, 1);
+    font-size: 1.2rem;
+    font-weight: bold;
+    padding: 5px;
+}
+.plain {
+    color: #ffffff;
+}
+#result {
+    clear: right;
+    display: grid;
+    grid-template-columns: minmax(1px, max-content) auto minmax(1px, max-content) minmax(1px, max-content) minmax(1px, max-content)
+}
+#result > div {
+    border-bottom: 1px solid #888888;
+    font-weight: bold;
+    padding: 5px 5px 2px 5px;
+    white-space: nowrap;
+}
+#result > .level {
+    color: #ffddaa;
+}
+#result > .title {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}
+#result > .score {
+    text-align: right;
+}
+#result > .miss_count {
+    text-align: right;
+    color:#aaaaff;
+}
+
+.NORMAL {
+    color: #8888ff;
+}
+.HYPER {
+    color: #ffff88;
+}
+.ANOTHER {
+    color: #ff8888;
+}
+.LEGGENDARIA {
+    color: #ff88ff;
+}
+
+.lamp.FAILED {
+    color: #ff0000;
+}
+.lamp.A-CLEAR {
+    color: #cc44ff;
+}
+.lamp.E-CLEAR {
+    color: #00ff22;
+}
+.lamp.CLEAR {
+    color: #22aaff;
+}
+.lamp.H-CLEAR {
+    color: #ff2222;
+}
+.lamp.EXH-CLEAR {
+    color: #ffff22;
+}
+.lamp.F-COMBO {
+    color: #ff22ff;
+    animation-name: flashfc;
+    animation-duration: 0.5s;
+    animation-iteration-count: infinite;
+}
+
+@keyframes flashfc {
+    0%   { color: #ff2828; }
+    20%  { color: #d5ff28; }
+    40%  { color: #28ff7e; }
+    60%  { color: #2872ff; }
+    80%  { color: #d528ff; }
+    100% { color: #ff2828; }
+}

--- a/export/recent_updates.html
+++ b/export/recent_updates.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Recent updates</title>
+        <link rel="stylesheet" href="./setting.css">
+        <link rel="stylesheet" href="./recent_updates.css">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+        <script src="./recent_updates.js"></script>
+    </head>
+<body>
+  <div id="setting">
+    <span>リザルト手帳を起動してください。</span>
+    <div id="box"></div>
+    <span id="url"></span>
+    <div id="box"></div>
+    <span>接続先URLは同フォルダのsetting.cssで変更できます。</span>
+    <span>変更後はリロードしてください。</span>
+  </div>
+  <div id="content">
+    <div id="title">Recent updates</div>
+    <div id="result"></div>
+  </div>
+</body>
+</html>

--- a/export/recent_updates.js
+++ b/export/recent_updates.js
@@ -1,0 +1,158 @@
+// 「最近」として表示する履歴の範囲 (単位:時間)
+const timeWindow = 12;
+
+// 更新のあるリザルトのみに表示を絞るか
+const showUpdatedOnly = true;
+
+let url = null;
+let socket = null;
+let musictable = null;
+let looprequest = null;
+
+async function connect() {
+    console.log("connecting...");
+    if(socket != null) return;
+
+    socket = new WebSocket(url);
+
+    socket.addEventListener('open', (event) => {
+        console.log("websocket opened.");
+        socket.send('get_musictable');
+    });
+
+    socket.addEventListener('message', (event) => {
+        console.log("message received.");
+        if(typeof event.data === 'string') {
+            try {
+                let data = JSON.parse(event.data);
+                if (data.method == 'get_musictable') {
+                    musictable = data.result;
+                    // 楽曲リストをロードできたら、履歴表示を開始
+                    clearInterval(looprequest);
+                    $("#setting").css("display", "none");
+                    $("#content").css("display", "block");
+                    looprequest = setInterval(loadJson, 1000);
+                }
+            } catch(e) {
+                console.log(e);
+            }
+        }
+    });
+
+    socket.addEventListener('error', (event) => {
+        console.log("websocket error:");
+        console.log(event);
+        socket.close();
+    });
+
+    socket.addEventListener('close', (event) => {
+        console.log("websocket closed.");
+        socket = null;
+    });
+}
+
+function loadJson() {
+    let getjson = $.ajax({
+        url: '../records/recent.json',
+        type: 'GET',
+        dataType: 'json',
+        cache: false
+    });
+
+    getjson.done(function(json){
+        let out = "<div></div><div class='header'>Music</div><div class='header'>Lamp</div><div class='header'>Score</div><div class='header'>BP</div>";
+        let timestamps = json["timestamps"];
+
+        // 履歴の足切り日時の文字列を yyyymmdd-hhmmss 形式で取得
+        let now = new Date();
+        let threshold = new Date(now.getTime() - timeWindow * 60 * 60 * 1000);
+        let yyyy = threshold.getFullYear().toString();
+        let mm = (threshold.getMonth() + 1).toString().padStart(2, '0');
+        let dd = threshold.getDate().toString().padStart(2, '0');
+        let hh = threshold.getHours().toString().padStart(2, '0');
+        let min = threshold.getMinutes().toString().padStart(2, '0');
+        let ss = threshold.getSeconds().toString().padStart(2, '0');
+        let timestamp_threshold = yyyy + mm + dd + '-' + hh + min + ss;
+
+        timestamps.filter(ts => ts > timestamp_threshold).sort((a, b) => b.localeCompare(a)).forEach(function(ts){
+            let entry = json["results"][ts];
+
+            if (showUpdatedOnly && !entry["update_clear_type"] && !entry["update_dj_level"] && !entry["update_score"] && !entry["update_miss_count"]) {
+                return;
+            }
+
+            let difficulty = entry["difficulty"];
+            let playtype = entry["playtype"];
+            let title = entry["music"];
+            let playspeed = entry["playspeed"];
+            let lamp = entry["update_clear_type"];
+            let score = entry["update_score"];
+            let bp = entry["update_miss_count"];
+            let options = entry["option"];
+            
+            let level = null;
+            try {
+                if (playtype == "DP") {
+                    level = musictable["musics"][title]["DP"][difficulty];
+                } else {
+                    // DBの難易度はSP準拠
+                    level = musictable["musics"][title]["SP"][difficulty];
+                }
+            } catch(e) {
+            }
+
+            // DB系のプレイオプションを反映
+            let db_options = "";
+            if (playtype === "DP BATTLE") {
+                playtype = 'DP'
+                if (options.indexOf("A-SCR")<0){
+                    db_options = "皿あり";
+                }
+                if ((options.indexOf("MIR/OFF")>=0) || (options.indexOf("OFF/MIR")>=0)){
+                    db_options += 'DBM'
+                }
+                else if (options.indexOf("OFF/OFF")>=0){
+                    db_options += 'DB'
+                }
+                else if (options.indexOf("RAN/RAN")>=0){
+                    db_options += 'DBR'
+                }
+                else if (options.indexOf("S-RAN/S-RAN")>=0){
+                    db_options += 'DBSR'
+                }
+                else if (options.indexOf("H-RAN/H-RAN")>=0){
+                    db_options += 'DBHR'
+                }
+            }
+
+            title = `${title} (${playtype + difficulty.slice(0,1)})`
+            if (playspeed) {
+                title = `<span class="plain">(x${playspeed})</span> ${title}` 
+            }
+            if (db_options != ""){
+                title = `<span class="plain">(${db_options})</span> ${title}`;
+            }
+
+
+            out += `<div class="level">${level === null ? '' : '☆' + level}</div>`
+            out += `<div class="title ${difficulty}">${title}</div>`
+            out += `<div class="lamp ${lamp}">${lamp === null ? '' : lamp}</div>`
+            out += `<div class="score">${score === null ? '' : "+" + score}</div>`;
+            out += `<div class="miss_count">${bp === null ? '' : bp}</div>`;
+        });
+        $('#result').html(out);
+    });
+
+    getjson.fail(function(err) {
+        // alert('failed');
+    });
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    const cssValue = getComputedStyle($(':root')[0]).getPropertyValue('--ws-url').trim();
+    if(cssValue.length)
+        url = cssValue.replace(/^["']|["']$/g, '');
+    $('span#url').text(url);
+
+    looprequest = setInterval(connect, 5000);
+});

--- a/export/score_results.css
+++ b/export/score_results.css
@@ -1,0 +1,154 @@
+body {
+  background-color: rgba(0, 0, 0, 0.95);
+  font-family: "Meiryo";
+  color: #fff;
+  overflow: hidden;
+}
+
+div#setting {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: absolute;
+    padding: 100px 50px;
+}
+
+div#setting #box {
+    height: 10px;
+}
+
+div#setting span {
+}
+
+div#setting span#url {
+    width: 300px;
+    color: black;
+    background-color: white;
+    padding: 2px 5px;
+    border-style: solid;
+    border-width: 1px;
+    font-size: large;
+}
+
+#content{
+    display: none;
+}
+
+#title {
+  color: #aaddff;
+  background-color: rgba(0, 0, 0, 1);
+  font-size: 1.2rem;
+  font-weight: bold;
+  padding: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#best {
+  clear: right;
+  display: grid;
+  grid-template-columns: minmax(1px, max-content) minmax(1px, max-content) auto;
+}
+#result {
+  clear: right;
+  display: grid;
+  grid-template-columns: minmax(1px, max-content) minmax(1px, max-content) minmax(1px, max-content) minmax(1px, max-content) minmax(1px, max-content) minmax(1px, max-content) auto;
+}
+#best > div, #result > div {
+  font-size: 1.2rem;
+  font-weight: bold;
+  padding: 5px 5px 2px 5px;
+  white-space: nowrap;
+}
+
+.date {
+  color: #ffffaa;
+}
+.value {
+  text-align: right;
+}
+.score {
+  color: #ffffff;
+}
+.bp {
+  color: #ff8888;
+}
+.options {
+  color: #aaffaa;
+}
+
+.NORMAL {
+    color: #8888ff;
+}
+.HYPER {
+    color: #ffff88;
+}
+.ANOTHER {
+    color: #ff8888;
+}
+.LEGGENDARIA {
+    color: #ff88ff;
+}
+
+.AAA {
+  color: #ffff28;
+}
+.AA {
+  color: #c3c3c3;
+}
+.A {
+  color: #2ddf71;
+}
+.B {
+  color: #7777ff;
+}
+.C {
+  color: #7777ff;
+}
+.D {
+  color: #7777ff;
+}
+.E {
+  color: #7777ff;
+}
+.F {
+  color: #7777ff;
+}
+
+.F-COMBO {
+  animation-name: flashfc;
+  animation-duration: 0.2s;
+  animation-iteration-count: infinite;
+}
+@keyframes flashfc {
+  0%   { background-color: #ff2828; }
+  20%  { background-color: #d5ff28; }
+  40%  { background-color: #28ff7e; }
+  60%  { background-color: #2872ff; }
+  80%  { background-color: #d528ff; }
+  100% { background-color: #ff2828; }
+}
+.FAILED {
+  animation-name: flashfailed;
+  animation-duration: 0.08s;
+  animation-iteration-count: infinite;
+}
+@keyframes flashfailed {
+  0%   { background-color: #ff2828; }
+  50%  { background-color: #282828; }
+  100% { background-color: #ff2828; }
+}
+.A-CLEAR { background-color: #ff66ff; }
+.E-CLEAR { background-color: #22ff22; }
+.CLEAR { background-color: #22ccff; }
+.H-CLEAR { background-color: #ffffff; }
+.EXH-CLEAR {
+  animation-name: flashexh;
+  animation-duration: 0.08s;
+  animation-iteration-count: infinite;
+}
+@keyframes flashexh {
+  0%   { background-color: #ff2828; }
+  50%  { background-color: #ffff28; }
+  100% { background-color: #ff2828; }
+}

--- a/export/score_results.html
+++ b/export/score_results.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Score Results</title>
+        <link rel="stylesheet" href="./setting.css">
+        <link rel="stylesheet" href="./score_results.css">
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+        <script src="./score_results.js"></script>
+    </head>
+<body>
+  <div id="setting">
+    <span>リザルト手帳を起動してください。</span>
+    <div id="box"></div>
+    <span id="url"></span>
+    <div id="box"></div>
+    <span>接続先URLは同フォルダのsetting.cssで変更できます。</span>
+    <span>変更後はリロードしてください。</span>
+  </div>
+  <div id="content">
+    <div id="title"></div>
+    <div id="best"></div>
+    <div id="result"></div>
+  </div>
+</body>
+</html>

--- a/export/score_results.js
+++ b/export/score_results.js
@@ -1,0 +1,159 @@
+// 「最近」として表示する履歴の範囲 (単位:時間)
+const timeWindow = 168;
+
+// 更新のあるリザルトのみに表示を絞るか
+const showUpdatedOnly = false;
+
+let url = null;
+let socket = null;
+let musictable = null;
+let looprequest = null;
+
+async function connect() {
+    console.log("connecting...");
+    if(socket != null) return;
+
+    socket = new WebSocket(url);
+
+    socket.addEventListener('open', (event) => {
+        console.log("websocket opened.");
+        socket.send('get_musictable');
+    });
+
+    socket.addEventListener('message', (event) => {
+        console.log("message received.");
+        if(typeof event.data === 'string') {
+            try {
+                let data = JSON.parse(event.data);
+                if (data.method == 'get_musictable') {
+                    musictable = data.result;
+                    clearInterval(looprequest);
+                    looprequest = setInterval(function(){
+                        try {
+                            socket.send('get_scoreresult');
+                        } catch(e) {
+                            console.log(e);
+                            $("#setting").css("display", "flex");
+                            $("#content").css("display", "none");
+                            clearInterval(looprequest);
+                            looprequest = setInterval(connect, 1000);
+                        }
+                    }, 1000);
+                } else if (data.method == 'get_scoreresult') {
+                    // スコアリストをロードできたら、履歴表示を開始
+                    $("#setting").css("display", "none");
+                    $("#content").css("display", "block");
+                    applyData(data);
+                }
+            } catch(e) {
+                console.log(e);
+            }
+        }
+    });
+
+    socket.addEventListener('error', (event) => {
+        console.log("websocket error:");
+        console.log(event);
+        socket.close();
+    });
+
+    socket.addEventListener('close', (event) => {
+        console.log("websocket closed.");
+        socket = null;
+    });
+}
+
+function optionToString(options){
+    if (options === null) {
+        return "???";
+    }
+    let out = [];
+    if (options.arrange !== null) {
+        out.push(options.arrange);
+    }
+    if (options.flip !== null) {
+        out.push(options.flip);
+    }
+    if (options.battle) {
+        out.push("BATTLE");
+    }
+    if (options.assist !== null) {
+        out.push(options.assist);
+    }
+    return out.join(",");
+}
+
+function applyData(data) {
+    if (!data["result"]) {
+        return;
+    }
+    let timestamps = data["result"]["timestamps"];
+    let title = data["music"]["musicname"];
+    let difficulty = data["music"]["difficulty"];
+    let playtype = data["music"]["playtype"];
+    let level = null;
+    try {
+        if (playtype == "DP") {
+            level = musictable["musics"][title]["DP"][difficulty];
+        } else {
+            // DBの難易度はSP準拠
+            level = musictable["musics"][title]["SP"][difficulty];
+        }
+    } catch(e) {
+    }
+
+    $("#title").html(`☆${level} ${title} (${playtype == 'DP BATTLE' ? 'DB' : playtype}${difficulty.slice(0,1)})`);
+    
+    let best_score = "???";
+    let best_score_opt = "???";
+    if (data["result"]["best"]["score"] !== undefined) {
+        best_score = data["result"]["best"]["score"]["value"];
+        best_score_opt = optionToString(data["result"]["best"]["score"]["options"]);        
+    }
+    let best_bp = "???";
+    let best_bp_opt = "???";
+    if (data["result"]["best"]["miss_count"] !== undefined) {
+        best_bp = data["result"]["best"]["miss_count"]["value"];
+        best_bp_opt = optionToString(data["result"]["best"]["miss_count"]["options"]);
+    }
+    let best_html = "";
+    best_html += `<div class="score">best(score)</div><div class="score value">${best_score}</div><div class="options">${best_score_opt}</div>`;
+    best_html += `<div class="bp">best(bp)</div><div class="bp value">${best_bp}</div><div class="options">${best_bp_opt}</div>`;
+    $('#best').html(best_html);
+
+    let out = "";
+    timestamps.sort((a, b) => b.localeCompare(a)).forEach(function(ts){
+        let entry = data["result"]["history"][ts];
+        
+        let date = ts.slice(0,4) + '-' + ts.slice(4,6) + '-' + ts.slice(6,8);
+        let lamp = entry["clear_type"]["value"];
+        let rank = entry["dj_level"]["value"];
+        let score = entry["score"]["value"];
+        let playspeed = entry["playspeed"] ? `x${entry["playspeed"]}` : "";
+        let opt = optionToString(entry["options"]);
+        let bp = entry["miss_count"]["value"];
+        if (bp === null) {
+            bp = "???";
+        }
+
+        // テーブルに追加
+        out += `<div class="date">${date}</div>`;
+        out += `<div><span class="${lamp}">　</span></div>`;
+        out += `<div class="rank ${rank}">${rank}</div>`;
+        out += `<div class="score value">${score}</div>`;
+        out += `<div class="bp value">${bp}</div>`;
+        out += `<div class="plain">${playspeed}</div>`;
+        out += `<div class="options">${opt}</div>`;
+
+    });
+    $('#result').html(out);
+}
+
+window.addEventListener('DOMContentLoaded', function() {
+    const cssValue = getComputedStyle($(':root')[0]).getPropertyValue('--ws-url').trim();
+    if(cssValue.length)
+        url = cssValue.replace(/^["']|["']$/g, '');
+    $('span#url').text(url);
+
+    looprequest = setInterval(connect, 1000);
+});

--- a/main.pyw
+++ b/main.pyw
@@ -1056,8 +1056,15 @@ class GuiApi():
         if notebook is None:
             event.return_string(dumps(None))
             return
-
-        event.return_string(dumps(notebook.get_scoreresult(playtype, difficulty)))
+        
+        result = notebook.get_scoreresult(playtype, difficulty)
+        socket_server.scoreresult = result
+        socket_server.scoreresult_music = {
+            'musicname': musicname,
+            'playtype': playtype,
+            'difficulty': difficulty
+        }
+        event.return_string(dumps(result))
 
     def get_playresult(self, event: webui.Event):
         '''対象のリザルトの記録を返す
@@ -2152,7 +2159,7 @@ if __name__ == '__main__':
 
     socket_server = SocketServer(port=setting.port['socket'])
     socket_server.start()
-    socket_server.json_musictable = dumps(resource.musictable)
+    socket_server.musictable = resource.musictable
 
     webui.set_config(webui.Config.multi_client, True)
     webui.set_default_root_folder('web/')

--- a/main.pyw
+++ b/main.pyw
@@ -2152,6 +2152,7 @@ if __name__ == '__main__':
 
     socket_server = SocketServer(port=setting.port['socket'])
     socket_server.start()
+    socket_server.json_musictable = dumps(resource.musictable)
 
     webui.set_config(webui.Config.multi_client, True)
     webui.set_default_root_folder('web/')

--- a/socket_server.py
+++ b/socket_server.py
@@ -18,6 +18,7 @@ class SocketServer(Thread):
     imagevalue_screenshot: bytes = None
     imagevalue_scoreinformation: bytes = None
     imagevalue_scoregraph: bytes = None
+    json_musictable: str = None
 
     def __init__(self, port: int = None):
         if port is not None:
@@ -44,6 +45,10 @@ class SocketServer(Thread):
                         target = self.imagevalue_scoreinformation
                     if message == 'get_scoregraphimage':
                         target = self.imagevalue_scoregraph
+                    if message == 'get_musictable':
+                        target = '{}'
+                        if self.json_musictable is not None:
+                            target = self.json_musictable
 
                     if target is not None:
                         connection.send(target)

--- a/socket_server.py
+++ b/socket_server.py
@@ -1,6 +1,7 @@
 from threading import Thread
 from websockets.sync.server import WebSocketServer,ServerConnection,serve
 from logging import getLogger
+from json import dumps
 
 logger_child_name = 'socket server'
 
@@ -18,7 +19,9 @@ class SocketServer(Thread):
     imagevalue_screenshot: bytes = None
     imagevalue_scoreinformation: bytes = None
     imagevalue_scoregraph: bytes = None
-    json_musictable: str = None
+    musictable = None
+    scoreresult = None
+    scoreresult_music = None
 
     def __init__(self, port: int = None):
         if port is not None:
@@ -46,9 +49,15 @@ class SocketServer(Thread):
                     if message == 'get_scoregraphimage':
                         target = self.imagevalue_scoregraph
                     if message == 'get_musictable':
-                        target = '{}'
-                        if self.json_musictable is not None:
-                            target = self.json_musictable
+                        obj = { "method" : "get_musictable" }
+                        if self.musictable is not None:
+                            obj["result"] = self.musictable
+                        target = dumps(obj)
+                    if message == 'get_scoreresult':
+                        obj = { "method" : "get_scoreresult", "music": self.scoreresult_music }
+                        if self.scoreresult is not None:
+                            obj["result"] = self.scoreresult
+                        target = dumps(obj)
 
                     if target is not None:
                         connection.send(target)


### PR DESCRIPTION
リザルト手帳がアプリ内に持っているデータをWebSocket経由で外部から取得できるようなAPIがあると、リザルト手帳のデータを活用するような外部ツールを作りやすくなるため、追加を検討していただけないでしょうか。
(手元でforkを運用することもできるので、運用方針に合わなければクローズしていただいて大丈夫です)

このpull-requestでは
- 楽曲リスト(難易度情報)を取得するAPI
- リザルト手帳で現在選択中の楽曲のプレイ履歴を取得するAPI
を追加してみていますが、これを使うことで

選択中の楽曲のプレイ履歴を表示したり
<img width="638" height="375" alt="スクリーンショット 2025-12-07 115700" src="https://github.com/user-attachments/assets/a95f1362-aa6c-468f-bed9-d25319ba5d40" />

その日のプレイ履歴を表示したりできるようになります。
<img width="514" height="489" alt="スクリーンショット 2025-12-07 115547" src="https://github.com/user-attachments/assets/8a9e48d6-7f2d-4590-bf81-74f75c3cb831" />
