### PR TITLE
[fix] switch from polling to event-driven process

### DIFF
--- a/export/recent_updates.js
+++ b/export/recent_updates.js
@@ -4,146 +4,169 @@ const timeWindow = 12;
 // 更新のあるリザルトのみに表示を絞るか
 const showUpdatedOnly = true;
 
+const Events = Object.freeze({
+  UPDATE_RECENTRECORDS: 'update_recentrecords',
+});
+
+const Requests = Object.freeze({
+  GET_MUSICTABLE: 'get_musictable',
+  GET_RECENTRECORDS: 'get_recentrecords',
+});
+
+const Statuses = Object.freeze({
+  SUCCESS: 'success',
+  INVALID: 'invalid',
+  FAILED: 'failed',
+})
+
 let url = null;
 let socket = null;
 let musictable = null;
 let looprequest = null;
 
 async function connect() {
-    console.log("connecting...");
     if(socket != null) return;
 
     socket = new WebSocket(url);
 
     socket.addEventListener('open', (event) => {
-        console.log("websocket opened.");
-        socket.send(JSON.stringify({ "r" : "get_musictable" }));
+        sendmessage(Requests.GET_MUSICTABLE);
     });
 
     socket.addEventListener('message', (event) => {
-        console.log("message received.");
         try {
             let data = JSON.parse(event.data);
-            if (data.r == 'get_musictable') {
-                musictable = data.p.d;
-                // 楽曲リストをロードできたら、履歴表示を開始
-                clearInterval(looprequest);
-                $("#setting").css("display", "none");
-                $("#content").css("display", "block");
-                looprequest = setInterval(loadJson, 1000);
+            if('e' in data) {
+                if(data['e'] == Events.UPDATE_RECENTRECORDS) {
+                    sendmessage(Requests.GET_RECENTRECORDS);
+                }
+            }
+
+            if('s' in data && data['s'] == Statuses.SUCCESS) {
+                if (data.r == Requests.GET_MUSICTABLE) {
+                    musictable = data.p.d;
+                    $("#setting").css("display", "none");
+                    $("#content").css("display", "block");
+                    sendmessage(Requests.GET_RECENTRECORDS);
+                } else if (data.r == Requests.GET_RECENTRECORDS) {
+                    applyData(data.p.d);
+                }
             }
         } catch(e) {
-            console.log(e);
+            console.error(e);
         }
     });
 
     socket.addEventListener('error', (event) => {
-        console.log("websocket error:");
-        console.log(event);
+        console.error(event);
         socket.close();
     });
 
     socket.addEventListener('close', (event) => {
-        console.log("websocket closed.");
         socket = null;
     });
 }
 
-function loadJson() {
-    let getjson = $.ajax({
-        url: '../records/recent.json',
-        type: 'GET',
-        dataType: 'json',
-        cache: false
+function applyData(data) {
+    let out = "<div></div><div class='header'>Music</div><div class='header'>Lamp</div><div class='header'>Score</div><div class='header'>BP</div>";
+    let timestamps = data["timestamps"];
+
+    // 履歴の足切り日時の文字列を yyyymmdd-hhmmss 形式で取得
+    let now = new Date();
+    let threshold = new Date(now.getTime() - timeWindow * 60 * 60 * 1000);
+    let yyyy = threshold.getFullYear().toString();
+    let mm = (threshold.getMonth() + 1).toString().padStart(2, '0');
+    let dd = threshold.getDate().toString().padStart(2, '0');
+    let hh = threshold.getHours().toString().padStart(2, '0');
+    let min = threshold.getMinutes().toString().padStart(2, '0');
+    let ss = threshold.getSeconds().toString().padStart(2, '0');
+    let timestamp_threshold = yyyy + mm + dd + '-' + hh + min + ss;
+
+    timestamps.filter(ts => ts > timestamp_threshold).sort((a, b) => b.localeCompare(a)).forEach(function(ts){
+        let entry = data["results"][ts];
+
+        if (showUpdatedOnly && !entry["update_clear_type"] && !entry["update_dj_level"] && !entry["update_score"] && !entry["update_miss_count"]) {
+            return;
+        }
+
+        let difficulty = entry["difficulty"];
+        let playtype = entry["playtype"];
+        let title = entry["music"];
+        let playspeed = entry["playspeed"];
+        let lamp = entry["update_clear_type"];
+        let score = entry["update_score"];
+        let bp = entry["update_miss_count"];
+        let options = entry["option"];
+        
+        let level = null;
+        try {
+            if (playtype == "DP") {
+                level = musictable["musics"][title]["DP"][difficulty];
+            } else {
+                // DBの難易度はSP準拠
+                level = musictable["musics"][title]["SP"][difficulty];
+            }
+        } catch(e) {
+        }
+
+        // DB系のプレイオプションを反映
+        let db_options = "";
+        if (playtype === "DP BATTLE") {
+            playtype = 'DP'
+            if (options.indexOf("A-SCR")<0){
+                db_options = "皿あり";
+            }
+            if ((options.indexOf("MIR/OFF")>=0) || (options.indexOf("OFF/MIR")>=0)){
+                db_options += 'DBM'
+            }
+            else if (options.indexOf("OFF/OFF")>=0){
+                db_options += 'DB'
+            }
+            else if (options.indexOf("RAN/RAN")>=0){
+                db_options += 'DBR'
+            }
+            else if (options.indexOf("S-RAN/S-RAN")>=0){
+                db_options += 'DBSR'
+            }
+            else if (options.indexOf("H-RAN/H-RAN")>=0){
+                db_options += 'DBHR'
+            }
+        }
+
+        title = `${title} (${playtype + difficulty.slice(0,1)})`
+        if (playspeed) {
+            title = `<span class="plain">(x${playspeed})</span> ${title}` 
+        }
+        if (db_options != ""){
+            title = `<span class="plain">(${db_options})</span> ${title}`;
+        }
+
+
+        out += `<div class="level">${level === null ? '' : '☆' + level}</div>`
+        out += `<div class="title ${difficulty}">${title}</div>`
+        out += `<div class="lamp ${lamp}">${lamp === null ? '' : lamp}</div>`
+        out += `<div class="score">${score === null ? '' : "+" + score}</div>`;
+        out += `<div class="miss_count">${bp === null ? '' : bp}</div>`;
     });
+    $('#result').html(out);
+}
 
-    getjson.done(function(json){
-        let out = "<div></div><div class='header'>Music</div><div class='header'>Lamp</div><div class='header'>Score</div><div class='header'>BP</div>";
-        let timestamps = json["timestamps"];
+function sendmessage(request, payload = null) {
+  let message = null;
+  
+  if(payload !== null) {
+    message = {
+      'r': request,
+      'p': payload,
+    };
+  }
+  else {
+    message = {
+      'r': request,
+    };
+  }
 
-        // 履歴の足切り日時の文字列を yyyymmdd-hhmmss 形式で取得
-        let now = new Date();
-        let threshold = new Date(now.getTime() - timeWindow * 60 * 60 * 1000);
-        let yyyy = threshold.getFullYear().toString();
-        let mm = (threshold.getMonth() + 1).toString().padStart(2, '0');
-        let dd = threshold.getDate().toString().padStart(2, '0');
-        let hh = threshold.getHours().toString().padStart(2, '0');
-        let min = threshold.getMinutes().toString().padStart(2, '0');
-        let ss = threshold.getSeconds().toString().padStart(2, '0');
-        let timestamp_threshold = yyyy + mm + dd + '-' + hh + min + ss;
-
-        timestamps.filter(ts => ts > timestamp_threshold).sort((a, b) => b.localeCompare(a)).forEach(function(ts){
-            let entry = json["results"][ts];
-
-            if (showUpdatedOnly && !entry["update_clear_type"] && !entry["update_dj_level"] && !entry["update_score"] && !entry["update_miss_count"]) {
-                return;
-            }
-
-            let difficulty = entry["difficulty"];
-            let playtype = entry["playtype"];
-            let title = entry["music"];
-            let playspeed = entry["playspeed"];
-            let lamp = entry["update_clear_type"];
-            let score = entry["update_score"];
-            let bp = entry["update_miss_count"];
-            let options = entry["option"];
-            
-            let level = null;
-            try {
-                if (playtype == "DP") {
-                    level = musictable["musics"][title]["DP"][difficulty];
-                } else {
-                    // DBの難易度はSP準拠
-                    level = musictable["musics"][title]["SP"][difficulty];
-                }
-            } catch(e) {
-            }
-
-            // DB系のプレイオプションを反映
-            let db_options = "";
-            if (playtype === "DP BATTLE") {
-                playtype = 'DP'
-                if (options.indexOf("A-SCR")<0){
-                    db_options = "皿あり";
-                }
-                if ((options.indexOf("MIR/OFF")>=0) || (options.indexOf("OFF/MIR")>=0)){
-                    db_options += 'DBM'
-                }
-                else if (options.indexOf("OFF/OFF")>=0){
-                    db_options += 'DB'
-                }
-                else if (options.indexOf("RAN/RAN")>=0){
-                    db_options += 'DBR'
-                }
-                else if (options.indexOf("S-RAN/S-RAN")>=0){
-                    db_options += 'DBSR'
-                }
-                else if (options.indexOf("H-RAN/H-RAN")>=0){
-                    db_options += 'DBHR'
-                }
-            }
-
-            title = `${title} (${playtype + difficulty.slice(0,1)})`
-            if (playspeed) {
-                title = `<span class="plain">(x${playspeed})</span> ${title}` 
-            }
-            if (db_options != ""){
-                title = `<span class="plain">(${db_options})</span> ${title}`;
-            }
-
-
-            out += `<div class="level">${level === null ? '' : '☆' + level}</div>`
-            out += `<div class="title ${difficulty}">${title}</div>`
-            out += `<div class="lamp ${lamp}">${lamp === null ? '' : lamp}</div>`
-            out += `<div class="score">${score === null ? '' : "+" + score}</div>`;
-            out += `<div class="miss_count">${bp === null ? '' : bp}</div>`;
-        });
-        $('#result').html(out);
-    });
-
-    getjson.fail(function(err) {
-        // alert('failed');
-    });
+  socket.send(JSON.stringify(message));
 }
 
 window.addEventListener('DOMContentLoaded', function() {

--- a/main.pyw
+++ b/main.pyw
@@ -1114,14 +1114,7 @@ class GuiApi():
             return
         
         result = notebook.get_scoreresult(playtype, difficulty)
-        socket_server.scoreresult = {
-            'music': {
-                'musicname': musicname,
-                'playtype': playtype,
-                'difficulty': difficulty,
-            },
-            'result': result,
-        }
+        socket_server.update_scoreresult(musicname, playtype, difficulty, result)
         event.return_string(dumps(result))
 
     def get_playresult(self, event: webui.Event):
@@ -1169,6 +1162,7 @@ class GuiApi():
         
         notebook_recent.save()
 
+        socket_server.update_recentrecords(notebook_recent)
         self.send_message('update_recentrecords', False)
 
     def recents_save_resultimages_filtered(self, event: webui.Event):
@@ -1223,6 +1217,7 @@ class GuiApi():
                 if result.timestamp in new_filtereds:
                     result.filtered = True
             
+            socket_server.update_recentrecords(notebook_recent)
             self.send_message('update_recentrecords', False)
 
     def recents_post_results(self, event: webui.Event):
@@ -2186,6 +2181,7 @@ def insert_results(result: Result):
     while len(recentresults) > recent_maxcount:
         del recentresults[-1]
 
+    socket_server.update_recentrecords(notebook_recent)
     api.send_message('update_recentrecords', setting.display_result)
 
 def update_resultflag(row_index, saved=False, filtered=False):
@@ -2471,7 +2467,8 @@ if __name__ == '__main__':
 
     socket_server = SocketServer(port=setting.port['socket'])
     socket_server.start()
-    socket_server.musictable = resource.musictable
+    socket_server.update_musictable(resource.musictable)
+    socket_server.update_recentrecords(notebook_recent)
 
     webui.set_config(webui.Config.multi_client, True)
     webui.set_default_root_folder('web/')

--- a/socket_server.py
+++ b/socket_server.py
@@ -23,6 +23,12 @@ class Events():
     '''譜面記録画像の更新'''
     UPDATE_SCOREGRAPHIMAGE: str = 'update_scoregraphimage'
     '''グラフ画像の更新'''
+    UPDATE_MUSICTABLE: str = 'update_musictable'
+    '''楽曲テーブルの更新'''
+    UPDATE_SCORERESULT: str = 'update_scoreresult'
+    '''楽曲プレイ履歴の更新'''
+    UPDATE_RECENTRECORDS: str = 'update_recentrecords'
+    '''最近のリザルトの更新'''
 
 class Requests():
     '''リクエストの定義
@@ -43,6 +49,8 @@ class Requests():
     '''楽曲テーブルの取得'''
     GET_SCORERESULT: str = 'get_scoreresult'
     '''楽曲プレイ履歴の取得'''
+    GET_RECENTRECORDS: str = 'get_recentrecords'
+    '''最近のリザルトの取得'''
 
 class Statuses():
     '''レスポンス状態の定義
@@ -107,6 +115,7 @@ class SocketServer(Thread):
 
     musictable: dict[str, any] | None = None
     scoreresult: dict[str, any] | None = None
+    recentrecords: dict[str, any] | None = None
 
     def __init__(self, port: int = None):
         if port is not None:
@@ -144,6 +153,8 @@ class SocketServer(Thread):
                         payload = self.response_json(self.musictable)
                     if request == Requests.GET_SCORERESULT:
                         payload = self.response_json(self.scoreresult)
+                    if request == Requests.GET_RECENTRECORDS:
+                        payload = self.response_json(self.recentrecords)
                                         
                     if payload is not None:
                         message = {
@@ -202,6 +213,25 @@ class SocketServer(Thread):
     def update_scoregraph(self, encodedimage: str | None):
         self.encodedimage_scoregraph = encodedimage
         self.broadcast(Events.UPDATE_SCOREGRAPHIMAGE)
+
+    def update_musictable(self, musictable: dict[str, any]):
+        self.musictable = musictable
+        self.broadcast(Events.UPDATE_MUSICTABLE)
+
+    def update_recentrecords(self, notebook_recent):
+        self.recentrecords = notebook_recent.json
+        self.broadcast(Events.UPDATE_RECENTRECORDS)
+
+    def update_scoreresult(self, musicname:str, playtype:str, difficulty:str, result: dict[str, any] | None):
+        self.scoreresult = {
+            'music': {
+                'musicname': musicname,
+                'playtype': playtype,
+                'difficulty': difficulty,
+            },
+            'result': result,
+        }
+        self.broadcast(Events.UPDATE_SCORERESULT)
 
     def broadcast(self, event: str, payload: any = None):
         if payload is not None:


### PR DESCRIPTION
 - ポーリングでAPI呼び出ししていたのを、イベント駆動に変更しました。
 - recent_updates について、ローカルファイル (records/recent.json) を直接参照するのをやめ、最近の更新データはAPI経由で受け取るよう変更しました。
   - これによりHTMLを通常のブラウザで開いてもCORSエラーが発生することなく利用・デバッグできるようになりました。